### PR TITLE
Add cookie authentication type

### DIFF
--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -24,7 +24,7 @@ module Jira
       process(response, options)
     end
 
-  private
+  protected
 
     def process(response, options)
       json = response.body || {}
@@ -62,7 +62,15 @@ module Jira
     end
 
     def headers
-      { 'Content-Type' => 'application/json' }
+      { 'Content-Type' => 'application/json' }.merge(cookies)
+    end
+
+    def cookies
+      cookie = Jira::Core.cookie
+      unless cookie.empty?
+        return { 'cookie' => "#{cookie[:name]}=#{cookie[:value]}" }
+      end
+      {}
     end
 
   end

--- a/lib/jira/auth_api.rb
+++ b/lib/jira/auth_api.rb
@@ -1,0 +1,16 @@
+require 'faraday'
+require 'faraday_middleware'
+
+require_relative './api'
+
+module Jira
+  class AuthAPI < API
+
+  protected
+
+    def endpoint
+      "#{Jira::Core.url}/rest/auth/1"
+    end
+
+  end
+end

--- a/lib/jira/command.rb
+++ b/lib/jira/command.rb
@@ -14,6 +14,10 @@ module Jira
         @api ||= Jira::API.new
       end
 
+      def auth_api
+        @auth_api ||= Jira::AuthAPI.new
+      end
+
       def sprint_api
         @sprint_api ||= Jira::SprintAPI.new
       end

--- a/lib/jira/core.rb
+++ b/lib/jira/core.rb
@@ -27,7 +27,15 @@ module Jira
       # @return [String] JIRA token
       #
       def token
-        @token ||= ENV['JIRA_TOKEN'] || self.read(self.cli_path)[:global]['token']
+        @token ||= ENV['JIRA_TOKEN'] || config[:global]['token']
+      end
+
+      #
+      # @return [Hash] JIRA cookie
+      #
+      def cookie
+        return {} if config[:cookie].nil? || config[:cookie].empty?
+        { name: config[:cookie]['name'], value: config[:cookie]['value'] }
       end
 
       #


### PR DESCRIPTION
Users should be able to authenticate with Jira without
having their password stored in the .jira-cli ini file.
Therefore, jira install allows for the user to authenticate
with a cookie and use that session to execute general
operations.