### PR TITLE
commit.rb: Add dependency on Time class

### DIFF
--- a/lib/jira/command.rb
+++ b/lib/jira/command.rb
@@ -1,4 +1,6 @@
 # internal dependencies
+require 'time'
+
 require 'jira/api'
 require 'jira/sprint_api'
 require 'jira/auth_api'


### PR DESCRIPTION
Some builds of ruby change the libraries that are loaded
by default. Therefore, require time is loaded so that commands
that use it do not raise an error.