### PR TITLE
checkout.rb: Add command checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ruby gem CLI tool used to manage JIRA workflows leveraging git
     jira all                # Describes all local branches that match JIRA ticketing syntax
     jira assign             # Assign a ticket to a user
     jira attachments        # View ticket attachments
+    jira checkout <ticket>  # Checks out a ticket from JIRA in the git branch
     jira comment <command>  # Commands for comment operations in JIRA
     jira delete             # Deletes a ticket in JIRA and the git branch
     jira describe           # Describes the input ticket

--- a/lib/jira/commands/checkout.rb
+++ b/lib/jira/commands/checkout.rb
@@ -1,0 +1,87 @@
+module Jira
+  class CLI < Thor
+
+    desc "checkout <ticket>", "Checks out a ticket from JIRA in the git branch"
+    method_option :remote, aliases: "-r", type: :string, default: nil, lazy_default: "", banner: "REMOTE"
+    def checkout(ticket)
+      Command::Checkout.new(ticket, options).run
+    end
+
+  end
+
+  module Command
+    class Checkout < Base
+
+      attr_accessor :ticket, :options
+
+      def initialize(ticket, options)
+        self.ticket = ticket
+        self.options = options
+      end
+
+      def run
+        return unless Jira::Core.ticket?(ticket)
+        return if metadata.empty?
+        unless metadata['errorMessages'].nil?
+          on_failure
+          return
+        end
+        unless remote?
+          on_failure
+          return
+        end
+
+        create_branch unless branches.include?(ticket)
+        checkout_branch
+        reset_branch unless branches.include?(ticket)
+        on_success
+      end
+
+    private
+
+      def on_success
+        puts "Ticket #{ticket} checked out."
+      end
+
+      def on_failure
+        puts "No ticket checked out."
+      end
+
+      def branches
+        @branches ||= `git branch --list 2> /dev/null`.split(' ')
+        @branches.delete("*")
+        @branches
+      end
+
+      def create_branch
+        `git branch #{ticket} 2> /dev/null`
+      end
+
+      def checkout_branch
+        `git checkout #{ticket} 2> /dev/null`
+      end
+
+      def metadata
+        @metadata ||= api.get("issue/#{ticket}")
+      end
+
+      def remote
+        @remote ||= options['remote'] || io.select('Remote?', remotes)
+      end
+
+      def remotes
+        @remotes ||= `git remote 2> /dev/null`.split(' ')
+      end
+
+      def remote?
+        return true if remotes.include?(remote)
+        false
+      end
+
+      def reset_branch
+        `git reset --hard #{remote} 2> /dev/null`
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Sometimes a user would like to check out a JIRA issue to start
working on it. This command checks out that issue in the git
branch and resets that branch to the specified remote if the
branch is newly created.